### PR TITLE
Wrap internal utilities into a context provided from HotTable to its children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
       }
     },
     "handsontable/.config/plugin/eslint": {
+      "name": "eslint-plugin-handsontable",
       "version": "1.0.0",
       "dev": true
     },
@@ -36984,7 +36985,6 @@
       "devDependencies": {
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.9.0",
-        "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.9.0",
         "@babel/polyfill": "^7.8.7",
         "@babel/preset-env": "^7.9.0",

--- a/wrappers/react/.babelrc
+++ b/wrappers/react/.babelrc
@@ -6,11 +6,15 @@
     "test": {
       "presets": [
         "@babel/env",
-        "@babel/preset-typescript"
+        [
+          "@babel/preset-typescript",
+          {
+            "allowDeclareFields": true
+          }
+        ]
       ],
       "plugins": [
-        "@babel/transform-runtime",
-        "@babel/plugin-proposal-class-properties"
+        "@babel/transform-runtime"
       ]
     }
   }

--- a/wrappers/react/package.json
+++ b/wrappers/react/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.9.0",

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -23,7 +23,7 @@ export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this co
 /**
  * String identifier for the global-scoped editor components.
  */
-export const GLOBAL_EDITOR_SCOPE = 'global';
+export const GLOBAL_EDITOR_SCOPE: EditorScopeIdentifier = 'global';
 
 /**
  * Default classname given to the wrapper container.

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -26,7 +26,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * @returns {Object}
    */
   getSettingsProps(): HotTableProps {
-    this.internalProps = ['_columnIndex', '_getEditorClass', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
+    this.internalProps = ['_columnIndex', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
 
     return Object.keys(this.props)
       .filter(key => {
@@ -63,7 +63,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
     }
 
     if (editorElement !== null) {
-      this.columnSettings.editor = this.props._getEditorClass(editorElement, this.props._columnIndex);
+      this.columnSettings.editor = this.context.getEditorClass(editorElement, this.props._columnIndex);
     }
   }
 

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -26,8 +26,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * @returns {Object}
    */
   getSettingsProps(): HotTableProps {
-    this.internalProps = ['_columnIndex', '_getRendererWrapper',
-      '_getEditorClass', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
+    this.internalProps = ['_columnIndex', '_getEditorClass', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
 
     return Object.keys(this.props)
       .filter(key => {
@@ -59,7 +58,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
     this.columnSettings = SettingsMapper.getSettings(this.getSettingsProps()) as unknown as Handsontable.ColumnSettings;
 
     if (rendererElement !== null) {
-      this.columnSettings.renderer = this.props._getRendererWrapper(rendererElement);
+      this.columnSettings.renderer = this.context.getRendererWrapper(rendererElement);
       this.context.componentRendererColumns.set(this.props._columnIndex, true);
     }
 

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -12,10 +12,11 @@ import { useHotColumnContext } from './hotColumnContext'
 
 const isHotColumn = (childNode: any): childNode is ReactElement => childNode.type === HotColumn;
 
-const internalProps = ['_columnIndex', 'hot-renderer', 'hot-editor', 'children'];
+const internalProps = ['_columnIndex', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
 
 interface HotColumnInnerProps extends HotColumnProps {
   _columnIndex: number;
+  _getOwnerDocument: () => Document | null;
 }
 
 class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { HotTableProps, HotColumnProps } from './types';
 import {
   createEditorPortal,
-  getExtendedEditorElement,
+  getChildElementByType,
+  getExtendedEditorElement
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
 import Handsontable from 'handsontable/base';
@@ -52,7 +53,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * Create the column settings based on the data provided to the `HotColumn` component and it's child components.
    */
   createColumnSettings(): void {
-    const rendererElement = this.context.getChildElementByType(this.props.children, 'hot-renderer');
+    const rendererElement = getChildElementByType(this.props.children, 'hot-renderer');
     const editorElement = this.getLocalEditorElement();
 
     this.columnSettings = SettingsMapper.getSettings(this.getSettingsProps()) as unknown as Handsontable.ColumnSettings;

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -6,10 +6,18 @@ import {
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
 import Handsontable from 'handsontable/base';
+import { HotTableContext } from './hotTableContext';
 
 class HotColumn extends React.Component<HotColumnProps, {}> {
   internalProps: string[];
   columnSettings: Handsontable.ColumnSettings;
+
+  /**
+   * HotTableContext type assignment
+   */
+  static contextType = HotTableContext;
+
+  declare context: React.ContextType<typeof HotTableContext>;
 
   /**
    * Filter out all the internal properties and return an object with just the Handsontable-related props.
@@ -17,7 +25,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * @returns {Object}
    */
   getSettingsProps(): HotTableProps {
-    this.internalProps = ['_componentRendererColumns', '_emitColumnSettings', '_columnIndex', '_getChildElementByType', '_getRendererWrapper',
+    this.internalProps = ['_emitColumnSettings', '_columnIndex', '_getChildElementByType', '_getRendererWrapper',
       '_getEditorClass', '_getEditorCache', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
 
     return Object.keys(this.props)
@@ -51,7 +59,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
 
     if (rendererElement !== null) {
       this.columnSettings.renderer = this.props._getRendererWrapper(rendererElement);
-      this.props._componentRendererColumns.set(this.props._columnIndex, true);
+      this.context.componentRendererColumns.set(this.props._columnIndex, true);
     }
 
     if (editorElement !== null) {

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -25,8 +25,8 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * @returns {Object}
    */
   getSettingsProps(): HotTableProps {
-    this.internalProps = ['_emitColumnSettings', '_columnIndex', '_getChildElementByType', '_getRendererWrapper',
-      '_getEditorClass', '_getEditorCache', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
+    this.internalProps = ['_columnIndex', '_getRendererWrapper',
+      '_getEditorClass', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
 
     return Object.keys(this.props)
       .filter(key => {
@@ -45,14 +45,14 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * @returns {React.ReactElement} React editor component element.
    */
   getLocalEditorElement(): React.ReactElement | null {
-    return getExtendedEditorElement(this.props.children, this.props._getEditorCache(), this.props._columnIndex);
+    return getExtendedEditorElement(this.props.children, this.context.editorCache, this.props._columnIndex);
   }
 
   /**
    * Create the column settings based on the data provided to the `HotColumn` component and it's child components.
    */
   createColumnSettings(): void {
-    const rendererElement = this.props._getChildElementByType(this.props.children, 'hot-renderer');
+    const rendererElement = this.context.getChildElementByType(this.props.children, 'hot-renderer');
     const editorElement = this.getLocalEditorElement();
 
     this.columnSettings = SettingsMapper.getSettings(this.getSettingsProps()) as unknown as Handsontable.ColumnSettings;
@@ -71,7 +71,7 @@ class HotColumn extends React.Component<HotColumnProps, {}> {
    * Emit the column settings to the parent using a prop passed from the parent.
    */
   emitColumnSettings(): void {
-    this.props._emitColumnSettings(this.columnSettings, this.props._columnIndex);
+    this.context.emitColumnSettings(this.columnSettings, this.props._columnIndex);
   }
 
   /*

--- a/wrappers/react/src/hotColumnContext.tsx
+++ b/wrappers/react/src/hotColumnContext.tsx
@@ -21,7 +21,7 @@ const HotColumnContextProvider: React.FC<PropsWithChildren<HotColumnContextImpl>
   const contextImpl: HotColumnContextImpl = useMemo(() => ({
     columnIndex,
     getOwnerDocument
-  }), [columnIndex]);
+  }), [columnIndex, getOwnerDocument]);
 
   return (
     <HotColumnContext.Provider value={contextImpl}>{children}</HotColumnContext.Provider>

--- a/wrappers/react/src/hotColumnContext.tsx
+++ b/wrappers/react/src/hotColumnContext.tsx
@@ -1,0 +1,33 @@
+import React, { PropsWithChildren, useContext, useMemo } from 'react';
+
+export interface HotColumnContextImpl {
+  /**
+   * Column index within a HotTable.
+   */
+  readonly columnIndex: number;
+
+  /**
+   * Get the `Document` object corresponding to the main component element.
+   *
+   * @returns The `Document` object used by the component.
+   */
+  readonly getOwnerDocument: () => Document | null;
+}
+
+const HotColumnContext = React.createContext<HotColumnContextImpl | undefined>(undefined);
+
+const HotColumnContextProvider: React.FC<PropsWithChildren<HotColumnContextImpl>> = ({ columnIndex, getOwnerDocument, children }) => {
+
+  const contextImpl: HotColumnContextImpl = useMemo(() => ({
+    columnIndex,
+    getOwnerDocument
+  }), [columnIndex]);
+
+  return (
+    <HotColumnContext.Provider value={contextImpl}>{children}</HotColumnContext.Provider>
+  );
+};
+
+const useHotColumnContext = () => useContext(HotColumnContext);
+
+export { useHotColumnContext, HotColumnContextProvider };

--- a/wrappers/react/src/hotTable.tsx
+++ b/wrappers/react/src/hotTable.tsx
@@ -1,6 +1,7 @@
 import React, { ForwardRefExoticComponent, RefAttributes } from 'react';
 import { HotTableClass } from './hotTableClass';
 import { HotTableProps } from './types';
+import { HotTableContextProvider } from './hotTableContext'
 
 interface Version {
   version?: string;
@@ -14,9 +15,11 @@ const HotTable: HotTable = React.forwardRef<HotTableClass, HotTableProps>(({ chi
   const componentId = props.id ?? generatedId;
 
   return (
-    <HotTableClass id={componentId} {...props} ref={ref}>
-      {children}
-    </HotTableClass>
+    <HotTableContextProvider>
+      <HotTableClass id={componentId} {...props} ref={ref}>
+        {children}
+      </HotTableClass>
+    </HotTableContextProvider>
   );
 })
 

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -75,13 +75,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
   style: React.CSSProperties;
 
   /**
-   * Component used to manage the renderer portals.
-   *
-   * @type {React.Component}
-   */
-  renderersPortalManager: RenderersPortalManager = null;
-
-  /**
    * Package version getter.
    *
    * @returns The version number of the package.
@@ -239,11 +232,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
    * Handsontable's `afterViewRender` hook callback.
    */
   handsontableAfterViewRender(): void {
-    this.renderersPortalManager.setState({
-      portals: [...this.context.portalCacheArray.current]
-    }, () => {
-      this.context.portalCacheArray.current = [];
-    });
+    this.context.pushCellPortalsIntoPortalManager();
   }
 
   /**
@@ -255,15 +244,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
     if (this.hotInstance) {
       this.hotInstance.updateSettings(newSettings, false);
     }
-  }
-
-  /**
-   * Set the renderers portal manager ref.
-   *
-   * @param {React.ReactComponent} pmComponent The PortalManager component.
-   */
-  private setRenderersPortalManagerRef(pmComponent: RenderersPortalManager): void {
-    this.renderersPortalManager = pmComponent;
   }
 
   /*
@@ -338,7 +318,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
         <div ref={this.setHotElementRef.bind(this)} {...containerProps}>
           {hotColumnClones}
         </div>
-        <RenderersPortalManager ref={this.setRenderersPortalManagerRef.bind(this)} />
+        <RenderersPortalManager ref={this.context.setRenderersPortalManagerRef} />
         {editorPortal}
       </React.Fragment>
     )

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -82,13 +82,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
   style: React.CSSProperties;
 
   /**
-   * Array of object containing the column settings.
-   *
-   * @type {Array}
-   */
-  columnSettings: Handsontable.ColumnSettings[] = [];
-
-  /**
    * Component used to manage the renderer portals.
    *
    * @type {React.Component}
@@ -107,14 +100,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
    * @type {Map}
    */
   private renderedCellCache: Map<string, HTMLTableCellElement> = new Map();
-
-  /**
-   * Editor cache.
-   *
-   * @private
-   * @type {Map}
-   */
-  private editorCache: HotEditorCache = new Map();
 
   /**
    * Package version getter.
@@ -172,15 +157,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
    */
   getRenderedCellCache(): Map<string, HTMLTableCellElement> {
     return this.renderedCellCache;
-  }
-
-  /**
-   * Get the editor cache and return it.
-   *
-   * @returns {Map}
-   */
-  getEditorCache(): HotEditorCache {
-    return this.editorCache;
   }
 
   /**
@@ -266,7 +242,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
    */
   getEditorClass(editorElement: HotEditorElement, editorColumnScope: EditorScopeIdentifier = GLOBAL_EDITOR_SCOPE): typeof Handsontable.editors.BaseEditor {
     const editorClass = getOriginalEditorClass(editorElement);
-    const cachedComponent = this.getEditorCache().get(editorClass)?.get(editorColumnScope);
+    const cachedComponent = this.context.editorCache.get(editorClass)?.get(editorColumnScope);
 
     return this.makeEditorClass(cachedComponent);
   }
@@ -335,7 +311,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
    * @returns {React.ReactElement} React editor component element.
    */
   getGlobalEditorElement(): HotEditorElement | null {
-    return getExtendedEditorElement(this.props.children, this.getEditorCache());
+    return getExtendedEditorElement(this.props.children, this.context.editorCache);
   }
 
   /**
@@ -348,7 +324,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
     const globalRendererNode = this.getGlobalRendererElement();
     const globalEditorNode = this.getGlobalEditorElement();
 
-    newSettings.columns = this.columnSettings.length ? this.columnSettings : newSettings.columns;
+    newSettings.columns = this.context.columnsSettings.length ? this.context.columnsSettings : newSettings.columns;
 
     if (globalEditorNode) {
       newSettings.editor = this.getEditorClass(globalEditorNode, GLOBAL_EDITOR_SCOPE);
@@ -385,16 +361,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
         warn(AUTOSIZE_WARNING);
       }
     }
-  }
-
-  /**
-   * Sets the column settings based on information received from HotColumn.
-   *
-   * @param {HotTableProps} columnSettings Column settings object.
-   * @param {Number} columnIndex Column index.
-   */
-  setHotColumnSettings(columnSettings: Handsontable.ColumnSettings, columnIndex: number): void {
-    this.columnSettings[columnIndex] = columnSettings;
   }
 
   /**
@@ -493,15 +459,12 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
       .filter(isHotColumn)
       .map((childNode, columnIndex) => {
         return React.cloneElement(childNode, {
-          _emitColumnSettings: this.setHotColumnSettings.bind(this),
           _columnIndex: columnIndex,
-          _getChildElementByType: getChildElementByType.bind(this),
           _getRendererWrapper: this.getRendererWrapper.bind(this),
           _getEditorClass: this.getEditorClass.bind(this),
           _getOwnerDocument: this.getOwnerDocument.bind(this),
-          _getEditorCache: this.getEditorCache.bind(this),
           children: childNode.props.children
-        } as object);
+        });
       });
 
     const containerProps = getContainerAttributesProps(this.props);

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -1,7 +1,6 @@
 import Handsontable from 'handsontable/base';
 import React, { PropsWithChildren, useCallback, useMemo, useRef } from 'react';
-import { getChildElementByType } from './helpers'
-import {HotEditorCache} from './types'
+import { HotEditorCache } from './types'
 
 interface HotTableContextImpl {
   /**
@@ -22,8 +21,6 @@ interface HotTableContextImpl {
    * @param {Number} columnIndex Column index.
    */
   readonly emitColumnSettings: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
-
-  readonly getChildElementByType: (children: React.ReactNode, type: string) => React.ReactElement;
 
   /**
    * Editor cache.
@@ -48,7 +45,6 @@ const HotTableContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
     componentRendererColumns: componentRendererColumns.current,
     columnsSettings: columnsSettings.current,
     emitColumnSettings: setHotColumnSettings,
-    getChildElementByType: getChildElementByType,
     editorCache: editorCache.current,
   }), [setHotColumnSettings]);
 

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -1,24 +1,56 @@
-import React, { PropsWithChildren, useRef } from 'react';
+import Handsontable from 'handsontable/base';
+import React, { PropsWithChildren, useCallback, useMemo, useRef } from 'react';
+import { getChildElementByType } from './helpers'
+import {HotEditorCache} from './types'
 
 interface HotTableContextImpl {
-  componentRendererColumns: Map<number | 'global', boolean>;
+  /**
+   * Map with column indexes (or a string = 'global') as keys, and booleans as values. Each key represents a component-based editor
+   * declared for the used column index, or a global one, if the key is the `global` string.
+   */
+  readonly componentRendererColumns: Map<number | 'global', boolean>;
+
+  /**
+   * Array of object containing the column settings.
+   */
+  readonly columnsSettings: Handsontable.ColumnSettings[];
+
+  /**
+   * Sets the column settings based on information received from HotColumn.
+   *
+   * @param {HotTableProps} columnSettings Column settings object.
+   * @param {Number} columnIndex Column index.
+   */
+  readonly emitColumnSettings: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
+
+  readonly getChildElementByType: (children: React.ReactNode, type: string) => React.ReactElement;
+
+  /**
+   * Editor cache.
+   */
+  readonly editorCache: HotEditorCache;
 }
 
 const HotTableContext = React.createContext<HotTableContextImpl>(undefined);
 
 const HotTableContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
-  /**
-   * Map with column indexes (or a string = 'global') as keys, and booleans as values. Each key represents a component-based editor
-   * declared for the used column index, or a global one, if the key is the `global` string.
-   *
-   * @private
-   * @type {Map}
-   */
+  const columnsSettings = useRef<Handsontable.ColumnSettings[]>([]);
+
+  const setHotColumnSettings = useCallback((columnSettings: Handsontable.ColumnSettings, columnIndex: number) => {
+    columnsSettings.current[columnIndex] = columnSettings;
+  }, [])
+
   const componentRendererColumns = useRef<Map<number | 'global', boolean>>(new Map());
 
-  const contextImpl: HotTableContextImpl = {
+  const editorCache = useRef<HotEditorCache>(new Map());
+
+  const contextImpl: HotTableContextImpl = useMemo(() => ({
     componentRendererColumns: componentRendererColumns.current,
-  };
+    columnsSettings: columnsSettings.current,
+    emitColumnSettings: setHotColumnSettings,
+    getChildElementByType: getChildElementByType,
+    editorCache: editorCache.current,
+  }), [setHotColumnSettings]);
 
   return (
     <HotTableContext.Provider value={contextImpl}>{children}</HotTableContext.Provider>

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -1,0 +1,28 @@
+import React, { PropsWithChildren, useRef } from 'react';
+
+interface HotTableContextImpl {
+  componentRendererColumns: Map<number | 'global', boolean>;
+}
+
+const HotTableContext = React.createContext<HotTableContextImpl>(undefined);
+
+const HotTableContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  /**
+   * Map with column indexes (or a string = 'global') as keys, and booleans as values. Each key represents a component-based editor
+   * declared for the used column index, or a global one, if the key is the `global` string.
+   *
+   * @private
+   * @type {Map}
+   */
+  const componentRendererColumns = useRef<Map<number | 'global', boolean>>(new Map());
+
+  const contextImpl: HotTableContextImpl = {
+    componentRendererColumns: componentRendererColumns.current,
+  };
+
+  return (
+    <HotTableContext.Provider value={contextImpl}>{children}</HotTableContext.Provider>
+  );
+};
+
+export { HotTableContext, HotTableContextProvider };

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -4,7 +4,7 @@ import { EditorScopeIdentifier, HotEditorCache, HotEditorElement } from './types
 import { createPortal, getOriginalEditorClass, GLOBAL_EDITOR_SCOPE } from './helpers'
 import { RenderersPortalManager } from './renderersPortalManager'
 
-interface HotTableContextImpl {
+export interface HotTableContextImpl {
   /**
    * Map with column indexes (or a string = 'global') as keys, and booleans as values. Each key represents a component-based editor
    * declared for the used column index, or a global one, if the key is the `global` string.

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -43,7 +43,6 @@ export interface HotEditorProps {
  */
 export interface HotColumnProps extends Handsontable.ColumnSettings {
   _columnIndex?: number,
-  _getRendererWrapper?: (rendererNode: React.ReactElement) => typeof Handsontable.renderers.BaseRenderer;
   _getEditorClass?: (editorElement: React.ReactElement, editorColumnScope: EditorScopeIdentifier) => typeof Handsontable.editors.BaseEditor;
   _getOwnerDocument?: () => Document;
   children?: React.ReactNode;

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -43,7 +43,6 @@ export interface HotEditorProps {
  */
 export interface HotColumnProps extends Handsontable.ColumnSettings {
   _columnIndex?: number,
-  _getEditorClass?: (editorElement: React.ReactElement, editorColumnScope: EditorScopeIdentifier) => typeof Handsontable.editors.BaseEditor;
   _getOwnerDocument?: () => Document;
   children?: React.ReactNode;
 }

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -42,7 +42,5 @@ export interface HotEditorProps {
  * Properties related to the HotColumn architecture.
  */
 export interface HotColumnProps extends Handsontable.ColumnSettings {
-  _columnIndex?: number,
-  _getOwnerDocument?: () => Document;
   children?: React.ReactNode;
 }

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -42,7 +42,6 @@ export interface HotEditorProps {
  * Properties related to the HotColumn architecture.
  */
 export interface HotColumnProps extends Handsontable.ColumnSettings {
-  _componentRendererColumns?: Map<number | string, boolean>;
   _emitColumnSettings?: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
   _columnIndex?: number,
   _getChildElementByType?: (children: React.ReactNode, type: string) => React.ReactElement;

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -42,12 +42,9 @@ export interface HotEditorProps {
  * Properties related to the HotColumn architecture.
  */
 export interface HotColumnProps extends Handsontable.ColumnSettings {
-  _emitColumnSettings?: (columnSettings: Handsontable.ColumnSettings, columnIndex: number) => void;
   _columnIndex?: number,
-  _getChildElementByType?: (children: React.ReactNode, type: string) => React.ReactElement;
   _getRendererWrapper?: (rendererNode: React.ReactElement) => typeof Handsontable.renderers.BaseRenderer;
   _getEditorClass?: (editorElement: React.ReactElement, editorColumnScope: EditorScopeIdentifier) => typeof Handsontable.editors.BaseEditor;
-  _getEditorCache?: () => HotEditorCache;
   _getOwnerDocument?: () => Document;
   children?: React.ReactNode;
 }


### PR DESCRIPTION

### Context

Changing the way `HotTable` communicates with `HotColumn`s below. Right now, to avoid props passing and expose simple `<HotTable ...><HotColumn ... /></HotTable>` children-based API, the utilities are shared from `HotTable` to HotColumn via [React.Children iteration and cloneElement "magic"](https://github.com/handsontable/handsontable/blob/develop/wrappers/react/src/hotTableClass.tsx#L496). We agreed it's not idiomatic React and React way to do it would be to use context. 

However, it turned out that besides shared utils, the `HotColumn` instances get `columnIndex` prop which obviously its different for each children, so the only way to do it without forcing end-users to specify these indices is to keep a part of the current approach.

I also skipped moving `hotInstance` access to the context as right now there's no need to do so. `HotInstance` is initialized and accessed only from `HotTable` - moving it elsewhere will only introduce unnecessary complexity.

### How has this been tested?

* All the unit tests still pass. No new unit tests as this is an internal structural change with no intention to be observable from the outside.
* Example projects from the repo still work properly.
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

☝️ actually, none of them. This is purely a structural change with no behavior change intended.

### Related issue(s):
1. Discussion on RFC Draft: https://gist.github.com/evanSe/8c67315d837873c7f32f7446f027e5e7?permalink_comment_id=4824737#gistcomment-4824737

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [ ] My change requires a change to the documentation.
