### PR TITLE
Change the way renderer and editor might be passed to HotColumn and HotTable to use render props approach

### DIFF
--- a/wrappers/react/src/baseEditorComponent.tsx
+++ b/wrappers/react/src/baseEditorComponent.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 import Handsontable from 'handsontable/base';
-import { EditorScopeIdentifier, HotEditorProps } from './types';
+import { HotEditorProps } from './types';
 
-interface BaseEditorProps extends HotEditorProps {
-  editorColumnScope?: EditorScopeIdentifier;
-  emitEditorInstance?: (editor: BaseEditorComponent, column: EditorScopeIdentifier) => void,
-}
-
-class BaseEditorComponent<P = {}, S = {}, SS = any> extends React.Component<P & BaseEditorProps, S, SS> implements Handsontable.editors.BaseEditor {
+class BaseEditorComponent<P = {}, S = {}, SS = any> extends React.Component<P & HotEditorProps, S, SS> implements Handsontable.editors.BaseEditor {
   name = 'BaseEditorComponent';
   instance = null;
   row = null;
@@ -22,14 +17,14 @@ class BaseEditorComponent<P = {}, S = {}, SS = any> extends React.Component<P & 
   hot = null;
 
   componentDidMount() {
-    if (this.props.emitEditorInstance) {
-      this.props.emitEditorInstance(this, this.props.editorColumnScope);
+    if (this.props._emitEditorInstance) {
+      this.props._emitEditorInstance(this, this.props._editorColumnScope);
     }
   }
 
   componentDidUpdate() {
-    if (this.props.emitEditorInstance) {
-      this.props.emitEditorInstance(this, this.props.editorColumnScope);
+    if (this.props._emitEditorInstance) {
+      this.props._emitEditorInstance(this, this.props._editorColumnScope);
     }
   }
 

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -72,7 +72,8 @@ export function displayObsoleteRenderersEditorsWarning(children: React.ReactNode
  * @param {String} type Either `'hot-renderer'` or `'hot-editor'`.
  * @returns {Object|null} A child (React node) or `null`, if no child of that type was found.
  */
-export function getChildElementByType(children: React.ReactNode, type: 'hot-renderer' | 'hot-editor'): React.ReactElement | null {
+// TODO(3-hotrenderer-hoteditor): change to find
+function getChildElementByType(children: React.ReactNode, type: 'hot-renderer' | 'hot-editor'): React.ReactElement | null {
   const childrenArray: React.ReactNode[] = React.Children.toArray(children);
   const childrenCount: number = React.Children.count(children);
   let wantedChild: React.ReactNode | null = null;

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -15,6 +15,12 @@ export const AUTOSIZE_WARNING = 'Your `HotTable` configuration includes `autoRow
   ' the component-based renderers`. Disable `autoRowSize` and `autoColumnSize` to prevent row and column misalignment.';
 
 /**
+ * Warning message for the `hot-renderer` obsolete renderer passing method.
+ */
+export const OBSOLETE_HOTRENDERER_WARNING = 'Providing a component-based renderer using `hot-renderer`-annotated component is no longer supported. ' +
+  'Pass your component using `renderer` prop of the `HotTable` or `HotColumn` component instead.';
+
+/**
  * Message for the warning thrown if the Handsontable instance has been destroyed.
  */
 export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this component was destroyed and cannot be' +
@@ -166,6 +172,28 @@ export function createPortal(rElement: React.ReactElement, props, ownerDocument:
 
   return {
     portal: ReactDOM.createPortal(extendedRendererElement, portalContainer, `${props.row}-${props.col}-${Math.random()}`),
+    portalContainer
+  };
+}
+
+// TODO(3-hotrenderer-hoteditor)
+export function createPortal2(rElement: React.ReactElement, key: string, ownerDocument: Document = document): {
+  portal: React.ReactPortal,
+  portalContainer: HTMLElement
+} {
+  if (!ownerDocument) {
+    ownerDocument = document;
+  }
+
+  if (!bulkComponentContainer) {
+    bulkComponentContainer = ownerDocument.createDocumentFragment();
+  }
+
+  const portalContainer = ownerDocument.createElement('DIV');
+  bulkComponentContainer.appendChild(portalContainer);
+
+  return {
+    portal: ReactDOM.createPortal(rElement, portalContainer, key),
     portalContainer
   };
 }

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -51,7 +51,7 @@ export function warn(...args) {
  * Filter out and return elements of the provided `type` from the `HotColumn` component's children.
  *
  * @param {React.ReactNode} children HotTable children array.
- * @param {String} type `'hot-renderer'` or `'hot-editor'`.
+ * @param {String} type Either `'hot-renderer'` or `'hot-editor'`.
  * @returns {Object|null} A child (React node) or `null`, if no child of that type was found.
  */
 export function getChildElementByType(children: React.ReactNode, type: 'hot-renderer' | 'hot-editor'): React.ReactElement | null {

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -21,6 +21,12 @@ export const OBSOLETE_HOTRENDERER_WARNING = 'Providing a component-based rendere
   'Pass your component using `renderer` prop of the `HotTable` or `HotColumn` component instead.';
 
 /**
+ * Warning message for the `hot-editor` obsolete editor passing method.
+ */
+export const OBSOLETE_HOTEDITOR_WARNING = 'Providing a component-based editor using `hot-editor`-annotated component is no longer supported. ' +
+  'Pass your component using `editor` prop of the `HotTable` or `HotColumn` component instead.';
+
+/**
  * Message for the warning thrown if the Handsontable instance has been destroyed.
  */
 export const HOT_DESTROYED_WARNING = 'The Handsontable instance bound to this component was destroyed and cannot be' +
@@ -44,6 +50,18 @@ export const DEFAULT_CLASSNAME = 'hot-wrapper-editor-container';
 export function warn(...args) {
   if (typeof console !== 'undefined') {
     console.warn(...args);
+  }
+}
+
+/**
+ * Detect if `hot-renderer` or `hot-editor` is defined, and if so, throw an incompatibility warning.
+ */
+export function displayObsoleteRenderersEditorsWarning(children: React.ReactNode): void {
+  if (getChildElementByType(children, 'hot-renderer')) {
+    warn(OBSOLETE_HOTRENDERER_WARNING);
+  }
+  if (getChildElementByType(children, 'hot-editor')) {
+    warn(OBSOLETE_HOTEDITOR_WARNING);
   }
 }
 

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {
   EditorScopeIdentifier,
-  HotEditorCache,
-  HotEditorElement
+  HotEditorElement,
+  HotEditorProps
 } from './types';
+import BaseEditorComponent from './baseEditorComponent'
 
 let bulkComponentContainer = null;
 
@@ -57,53 +58,27 @@ export function warn(...args) {
  * Detect if `hot-renderer` or `hot-editor` is defined, and if so, throw an incompatibility warning.
  */
 export function displayObsoleteRenderersEditorsWarning(children: React.ReactNode): void {
-  if (getChildElementByType(children, 'hot-renderer')) {
+  if (hasChildElementOfType(children, 'hot-renderer')) {
     warn(OBSOLETE_HOTRENDERER_WARNING);
   }
-  if (getChildElementByType(children, 'hot-editor')) {
+  if (hasChildElementOfType(children, 'hot-editor')) {
     warn(OBSOLETE_HOTEDITOR_WARNING);
   }
 }
 
 /**
- * Filter out and return elements of the provided `type` from the `HotColumn` component's children.
+ * Check the existence of elements of the provided `type` from the `HotColumn` component's children.
  *
  * @param {React.ReactNode} children HotTable children array.
  * @param {String} type Either `'hot-renderer'` or `'hot-editor'`.
- * @returns {Object|null} A child (React node) or `null`, if no child of that type was found.
+ * @returns {boolean} `true` if the child of that type was found, `false` otherwise.
  */
-// TODO(3-hotrenderer-hoteditor): change to find
-function getChildElementByType(children: React.ReactNode, type: 'hot-renderer' | 'hot-editor'): React.ReactElement | null {
+function hasChildElementOfType(children: React.ReactNode, type: 'hot-renderer' | 'hot-editor'): boolean {
   const childrenArray: React.ReactNode[] = React.Children.toArray(children);
-  const childrenCount: number = React.Children.count(children);
-  let wantedChild: React.ReactNode | null = null;
 
-  if (childrenCount !== 0) {
-    if (childrenCount === 1 && (childrenArray[0] as React.ReactElement).props[type]) {
-      wantedChild = childrenArray[0];
-
-    } else {
-      wantedChild = childrenArray.find((child) => {
-        return (child as React.ReactElement).props[type] !== void 0;
-      });
-    }
-  }
-
-  return (wantedChild as React.ReactElement) || null;
-}
-
-/**
- * Get the reference to the original editor class.
- *
- * @param {React.ReactElement} editorElement React element of the editor class.
- * @returns {Function} Original class of the editor component.
- */
-export function getOriginalEditorClass(editorElement: HotEditorElement) {
-  if (!editorElement) {
-    return null;
-  }
-
-  return editorElement.type.WrappedComponent ? editorElement.type.WrappedComponent : editorElement.type;
+  return childrenArray.some((child) => {
+    return (child as React.ReactElement).props[type] !== void 0;
+  });
 }
 
 /**
@@ -132,33 +107,18 @@ export function createEditorPortal(doc: Document, editorElement: HotEditorElemen
 /**
  * Get an editor element extended with an instance-emitting method.
  *
- * @param {React.ReactNode} children Component children.
- * @param {Map} editorCache Component's editor cache.
+ * @param {React.ComponentType} Editor TODO.
+ * @param {Function} emitEditorInstance TODO.
  * @param {EditorScopeIdentifier} [editorColumnScope] The editor scope (column index or a 'global' string). Defaults to
  * 'global'.
  * @returns {React.ReactElement} An editor element containing the additional methods.
  */
-export function getExtendedEditorElement(children: React.ReactNode, editorCache: HotEditorCache, editorColumnScope: EditorScopeIdentifier = GLOBAL_EDITOR_SCOPE): React.ReactElement | null {
-  const editorElement = getChildElementByType(children, 'hot-editor');
-  const editorClass = getOriginalEditorClass(editorElement);
-
-  if (!editorElement) {
+export function getExtendedEditorElement(Editor: React.ComponentType<HotEditorProps> | undefined, emitEditorInstance: (editor: BaseEditorComponent, column: EditorScopeIdentifier) => void, editorColumnScope: EditorScopeIdentifier = GLOBAL_EDITOR_SCOPE): HotEditorElement {
+  if (!Editor) {
     return null;
   }
 
-  return React.cloneElement(editorElement, {
-    emitEditorInstance: (editorInstance, editorColumnScope) => {
-      if (!editorCache.get(editorClass)) {
-        editorCache.set(editorClass, new Map());
-      }
-
-      const cacheEntry = editorCache.get(editorClass);
-
-      cacheEntry.set(editorColumnScope ?? GLOBAL_EDITOR_SCOPE, editorInstance);
-    },
-    editorColumnScope,
-    isEditor: true
-  } as object);
+  return <Editor _emitEditorInstance={emitEditorInstance} _editorColumnScope={editorColumnScope}/>
 }
 
 /**

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -51,10 +51,10 @@ export function warn(...args) {
  * Filter out and return elements of the provided `type` from the `HotColumn` component's children.
  *
  * @param {React.ReactNode} children HotTable children array.
- * @param {String} type `'hot-editor'`.
+ * @param {String} type `'hot-renderer'` or `'hot-editor'`.
  * @returns {Object|null} A child (React node) or `null`, if no child of that type was found.
  */
-export function getChildElementByType(children: React.ReactNode, type: 'hot-editor'): React.ReactElement | null {
+export function getChildElementByType(children: React.ReactNode, type: 'hot-renderer' | 'hot-editor'): React.ReactElement | null {
   const childrenArray: React.ReactNode[] = React.Children.toArray(children);
   const childrenCount: number = React.Children.count(children);
   let wantedChild: React.ReactNode | null = null;

--- a/wrappers/react/src/helpers.tsx
+++ b/wrappers/react/src/helpers.tsx
@@ -51,10 +51,10 @@ export function warn(...args) {
  * Filter out and return elements of the provided `type` from the `HotColumn` component's children.
  *
  * @param {React.ReactNode} children HotTable children array.
- * @param {String} type Either `'hot-renderer'` or `'hot-editor'`.
+ * @param {String} type `'hot-editor'`.
  * @returns {Object|null} A child (React node) or `null`, if no child of that type was found.
  */
-export function getChildElementByType(children: React.ReactNode, type: string): React.ReactElement | null {
+export function getChildElementByType(children: React.ReactNode, type: 'hot-editor'): React.ReactElement | null {
   const childrenArray: React.ReactNode[] = React.Children.toArray(children);
   const childrenCount: number = React.Children.count(children);
   let wantedChild: React.ReactNode | null = null;
@@ -143,41 +143,14 @@ export function getExtendedEditorElement(children: React.ReactNode, editorCache:
 }
 
 /**
- * Create a react component and render it to an external DOM done.
+ * Render a cell component to an external DOM node.
  *
  * @param {React.ReactElement} rElement React element to be used as a base for the component.
- * @param {Object} props Props to be passed to the cloned element.
+ * @param {Object} key Unique identifier of the cell element.
  * @param {Document} [ownerDocument] The owner document to set the portal up into.
  * @returns {{portal: React.ReactPortal, portalContainer: HTMLElement}} An object containing the portal and its container.
  */
-export function createPortal(rElement: React.ReactElement, props, ownerDocument: Document = document): {
-  portal: React.ReactPortal,
-  portalContainer: HTMLElement
-} {
-  if (!ownerDocument) {
-    ownerDocument = document;
-  }
-
-  if (!bulkComponentContainer) {
-    bulkComponentContainer = ownerDocument.createDocumentFragment();
-  }
-
-  const portalContainer = ownerDocument.createElement('DIV');
-  bulkComponentContainer.appendChild(portalContainer);
-
-  const extendedRendererElement = React.cloneElement(rElement, {
-    key: `${props.row}-${props.col}`,
-    ...props
-  });
-
-  return {
-    portal: ReactDOM.createPortal(extendedRendererElement, portalContainer, `${props.row}-${props.col}-${Math.random()}`),
-    portalContainer
-  };
-}
-
-// TODO(3-hotrenderer-hoteditor)
-export function createPortal2(rElement: React.ReactElement, key: string, ownerDocument: Document = document): {
+export function createPortal(rElement: React.ReactElement, key: string, ownerDocument: Document = document): {
   portal: React.ReactPortal,
   portalContainer: HTMLElement
 } {

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -2,10 +2,8 @@ import React, { ReactElement } from 'react';
 import { HotTableProps, HotColumnProps } from './types';
 import {
   createEditorPortal,
-  getChildElementByType,
-  getExtendedEditorElement,
-  OBSOLETE_HOTRENDERER_WARNING,
-  warn
+  displayObsoleteRenderersEditorsWarning,
+  getExtendedEditorElement
 } from './helpers';
 import { SettingsMapper } from './settingsMapper';
 import Handsontable from 'handsontable/base';
@@ -84,15 +82,6 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
     this.context.emitColumnSettings(this.columnSettings, this.props._columnIndex);
   }
 
-  /**
-   * Detect if `hot-renderer` or `hot-editor` is defined, and if so, throw an incompatibility warning.
-   */
-  private displayObsoleteRenderersEditorsWarning(): void {
-    if (getChildElementByType(this.props.children, 'hot-renderer')) {
-      warn(OBSOLETE_HOTRENDERER_WARNING);
-    }
-  }
-
   /*
   ---------------------------------------
   ------- React lifecycle methods -------
@@ -105,7 +94,7 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
   componentDidMount(): void {
     this.createColumnSettings();
     this.emitColumnSettings();
-    this.displayObsoleteRenderersEditorsWarning();
+    displayObsoleteRenderersEditorsWarning(this.props.children);
   }
 
   /**
@@ -114,7 +103,7 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
   componentDidUpdate(): void {
     this.createColumnSettings();
     this.emitColumnSettings();
-    this.displayObsoleteRenderersEditorsWarning();
+    displayObsoleteRenderersEditorsWarning(this.props.children);
   }
 
   /**

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -1,6 +1,12 @@
 import React, { ReactElement } from 'react';
 import { HotTableProps, HotColumnProps } from './types';
-import { createEditorPortal, getExtendedEditorElement } from './helpers';
+import {
+  createEditorPortal,
+  getChildElementByType,
+  getExtendedEditorElement,
+  OBSOLETE_HOTRENDERER_WARNING,
+  warn
+} from './helpers';
 import { SettingsMapper } from './settingsMapper';
 import Handsontable from 'handsontable/base';
 import { HotTableContext } from './hotTableContext';
@@ -78,6 +84,15 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
     this.context.emitColumnSettings(this.columnSettings, this.props._columnIndex);
   }
 
+  /**
+   * Detect if `hot-renderer` or `hot-editor` is defined, and if so, throw an incompatibility warning.
+   */
+  private displayObsoleteRenderersEditorsWarning(): void {
+    if (getChildElementByType(this.props.children, 'hot-renderer')) {
+      warn(OBSOLETE_HOTRENDERER_WARNING);
+    }
+  }
+
   /*
   ---------------------------------------
   ------- React lifecycle methods -------
@@ -90,6 +105,7 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
   componentDidMount(): void {
     this.createColumnSettings();
     this.emitColumnSettings();
+    this.displayObsoleteRenderersEditorsWarning();
   }
 
   /**
@@ -98,6 +114,7 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
   componentDidUpdate(): void {
     this.createColumnSettings();
     this.emitColumnSettings();
+    this.displayObsoleteRenderersEditorsWarning();
   }
 
   /**

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -1,10 +1,6 @@
 import React, { ReactElement } from 'react';
 import { HotTableProps, HotColumnProps } from './types';
-import {
-  createEditorPortal,
-  getChildElementByType,
-  getExtendedEditorElement
-} from './helpers';
+import { createEditorPortal, getExtendedEditorElement } from './helpers';
 import { SettingsMapper } from './settingsMapper';
 import Handsontable from 'handsontable/base';
 import { HotTableContext } from './hotTableContext';
@@ -12,7 +8,7 @@ import { useHotColumnContext } from './hotColumnContext'
 
 const isHotColumn = (childNode: any): childNode is ReactElement => childNode.type === HotColumn;
 
-const internalProps = ['_columnIndex', '_getOwnerDocument', 'hot-renderer', 'hot-editor', 'children'];
+const internalProps = ['_columnIndex', '_getOwnerDocument', 'hot-editor', 'children'];
 
 interface HotColumnInnerProps extends HotColumnProps {
   _columnIndex: number;
@@ -59,14 +55,15 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
    * Create the column settings based on the data provided to the `HotColumn` component and it's child components.
    */
   createColumnSettings(): void {
-    const rendererElement = getChildElementByType(this.props.children, 'hot-renderer');
     const editorElement = this.getLocalEditorElement();
 
     this.columnSettings = SettingsMapper.getSettings(this.getSettingsProps()) as unknown as Handsontable.ColumnSettings;
 
-    if (rendererElement !== null) {
-      this.columnSettings.renderer = this.context.getRendererWrapper(rendererElement);
+    if (this.props.renderer) {
+      this.columnSettings.renderer = this.context.getRendererWrapper(this.props.renderer);
       this.context.componentRendererColumns.set(this.props._columnIndex, true);
+    } else if (this.props.hotRenderer) {
+      this.columnSettings.renderer = this.props.hotRenderer;
     }
 
     if (editorElement !== null) {

--- a/wrappers/react/src/hotColumn.tsx
+++ b/wrappers/react/src/hotColumn.tsx
@@ -12,7 +12,7 @@ import { useHotColumnContext } from './hotColumnContext'
 
 const isHotColumn = (childNode: any): childNode is ReactElement => childNode.type === HotColumn;
 
-const internalProps = ['_columnIndex', '_getOwnerDocument', 'hot-editor', 'children'];
+const internalProps = ['_columnIndex', '_getOwnerDocument', 'children'];
 
 interface HotColumnInnerProps extends HotColumnProps {
   _columnIndex: number;
@@ -47,20 +47,9 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
   }
 
   /**
-   * Get the editor element for the current column.
-   *
-   * @returns {React.ReactElement} React editor component element.
-   */
-  getLocalEditorElement(): React.ReactElement | null {
-    return getExtendedEditorElement(this.props.children, this.context.editorCache, this.props._columnIndex);
-  }
-
-  /**
    * Create the column settings based on the data provided to the `HotColumn` component and it's child components.
    */
   createColumnSettings(): void {
-    const editorElement = this.getLocalEditorElement();
-
     this.columnSettings = SettingsMapper.getSettings(this.getSettingsProps()) as unknown as Handsontable.ColumnSettings;
 
     if (this.props.renderer) {
@@ -70,8 +59,10 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
       this.columnSettings.renderer = this.props.hotRenderer;
     }
 
-    if (editorElement !== null) {
-      this.columnSettings.editor = this.context.getEditorClass(editorElement, this.props._columnIndex);
+    if (this.props.editor) {
+      this.columnSettings.editor = this.context.getEditorClass(this.props._columnIndex);
+    } else if (this.props.hotEditor) {
+      this.columnSettings.editor = this.props.hotEditor;
     }
   }
 
@@ -112,7 +103,8 @@ class HotColumnInner extends React.Component<HotColumnInnerProps, {}> {
    * @returns {React.ReactElement}
    */
   render(): React.ReactElement {
-    const editorPortal = createEditorPortal(this.props._getOwnerDocument(), this.getLocalEditorElement());
+    const localEditorElement = getExtendedEditorElement(this.props.editor, this.context.emitEditorInstance, this.props._columnIndex);
+    const editorPortal = createEditorPortal(this.props._getOwnerDocument(), localEditorElement);
 
     return (
       <React.Fragment>

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -9,7 +9,6 @@ import {
   AUTOSIZE_WARNING,
   GLOBAL_EDITOR_SCOPE,
   createEditorPortal,
-  getChildElementByType,
   getContainerAttributesProps,
   getExtendedEditorElement,
   isCSR,
@@ -155,15 +154,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
   }
 
   /**
-   * Get the renderer element for the entire HotTable instance.
-   *
-   * @returns {React.ReactElement} React renderer component element.
-   */
-  getGlobalRendererElement(): React.ReactElement {
-    return getChildElementByType(this.props.children, 'hot-renderer');
-  }
-
-  /**
    * Get the editor element for the entire HotTable instance.
    *
    * @param {React.ReactNode} [children] Children of the HotTable instance. Defaults to `this.props.children`.
@@ -180,7 +170,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
    */
   createNewGlobalSettings(): Handsontable.GridSettings {
     const newSettings = SettingsMapper.getSettings(this.props);
-    const globalRendererNode = this.getGlobalRendererElement();
     const globalEditorNode = this.getGlobalEditorElement();
 
     newSettings.columns = this.context.columnsSettings.length ? this.context.columnsSettings : newSettings.columns;
@@ -193,7 +182,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
     }
 
     if (this.props.renderer) {
-      newSettings.renderer = this.context.getRendererWrapper2(this.props.renderer);
+      newSettings.renderer = this.context.getRendererWrapper(this.props.renderer);
       this.context.componentRendererColumns.set('global', true);
     } else {
       newSettings.renderer = this.props.hotRenderer || undefined;

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -3,7 +3,7 @@ import Handsontable from 'handsontable/base';
 import { SettingsMapper } from './settingsMapper';
 import { RenderersPortalManager } from './renderersPortalManager';
 import * as packageJson from '../package.json';
-import { HotTableProps, HotEditorElement } from './types';
+import { HotTableProps } from './types';
 import {
   HOT_DESTROYED_WARNING,
   AUTOSIZE_WARNING,
@@ -155,31 +155,19 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
   }
 
   /**
-   * Get the editor element for the entire HotTable instance.
-   *
-   * @param {React.ReactNode} [children] Children of the HotTable instance. Defaults to `this.props.children`.
-   * @returns {React.ReactElement} React editor component element.
-   */
-  getGlobalEditorElement(): HotEditorElement | null {
-    return getExtendedEditorElement(this.props.children, this.context.editorCache);
-  }
-
-  /**
    * Create a new settings object containing the column settings and global editors and renderers.
    *
    * @returns {Handsontable.GridSettings} New global set of settings for Handsontable.
    */
   createNewGlobalSettings(): Handsontable.GridSettings {
     const newSettings = SettingsMapper.getSettings(this.props);
-    const globalEditorNode = this.getGlobalEditorElement();
 
     newSettings.columns = this.context.columnsSettings.length ? this.context.columnsSettings : newSettings.columns;
 
-    if (globalEditorNode) {
-      newSettings.editor = this.context.getEditorClass(globalEditorNode, GLOBAL_EDITOR_SCOPE);
-
+    if (this.props.editor) {
+      newSettings.editor = this.context.getEditorClass(GLOBAL_EDITOR_SCOPE);
     } else {
-      newSettings.editor = this.props.editor || undefined;
+      newSettings.editor = this.props.hotEditor || undefined;
     }
 
     if (this.props.renderer) {
@@ -299,7 +287,8 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
       ));
 
     const containerProps = getContainerAttributesProps(this.props);
-    const editorPortal = createEditorPortal(this.getOwnerDocument(), this.getGlobalEditorElement());
+    const globalEditorElement = getExtendedEditorElement(this.props.editor, this.context.emitEditorInstance)
+    const editorPortal = createEditorPortal(this.getOwnerDocument(), globalEditorElement);
 
     return (
       <React.Fragment>

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -192,12 +192,11 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
       newSettings.editor = this.props.editor || undefined;
     }
 
-    if (globalRendererNode) {
-      newSettings.renderer = this.context.getRendererWrapper(globalRendererNode);
+    if (this.props.renderer) {
+      newSettings.renderer = this.context.getRendererWrapper2(this.props.renderer);
       this.context.componentRendererColumns.set('global', true);
-
     } else {
-      newSettings.renderer = this.props.renderer || undefined;
+      newSettings.renderer = this.props.hotRenderer || undefined;
     }
 
     return newSettings;

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -13,8 +13,7 @@ import {
   getExtendedEditorElement,
   isCSR,
   warn,
-  getChildElementByType,
-  OBSOLETE_HOTRENDERER_WARNING
+  displayObsoleteRenderersEditorsWarning
 } from './helpers';
 import PropTypes from 'prop-types';
 import { HotTableContext } from './hotTableContext'
@@ -213,15 +212,6 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
   }
 
   /**
-   * Detect if `hot-renderer` or `hot-editor` is defined, and if so, throw an incompatibility warning.
-   */
-  private displayObsoleteRenderersEditorsWarning(): void {
-    if (getChildElementByType(this.props.children, 'hot-renderer')) {
-      warn(OBSOLETE_HOTRENDERER_WARNING);
-    }
-  }
-
-  /**
    * Handsontable's `beforeViewRender` hook callback.
    */
   handsontableBeforeViewRender(): void {
@@ -267,7 +257,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
     (this.hotInstance as any).init();
 
     this.displayAutoSizeWarning(newGlobalSettings);
-    this.displayObsoleteRenderersEditorsWarning();
+    displayObsoleteRenderersEditorsWarning(this.props.children);
   }
 
   /**
@@ -280,7 +270,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
 
     this.updateHot(newGlobalSettings);
     this.displayAutoSizeWarning(newGlobalSettings);
-    this.displayObsoleteRenderersEditorsWarning();
+    displayObsoleteRenderersEditorsWarning(this.props.children);
   }
 
   /**

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -12,7 +12,9 @@ import {
   getContainerAttributesProps,
   getExtendedEditorElement,
   isCSR,
-  warn, getChildElementByType, OBSOLETE_HOTRENDERER_WARNING
+  warn,
+  getChildElementByType,
+  OBSOLETE_HOTRENDERER_WARNING
 } from './helpers';
 import PropTypes from 'prop-types';
 import { HotTableContext } from './hotTableContext'

--- a/wrappers/react/src/hotTableClass.tsx
+++ b/wrappers/react/src/hotTableClass.tsx
@@ -12,7 +12,7 @@ import {
   getContainerAttributesProps,
   getExtendedEditorElement,
   isCSR,
-  warn
+  warn, getChildElementByType, OBSOLETE_HOTRENDERER_WARNING
 } from './helpers';
 import PropTypes from 'prop-types';
 import { HotTableContext } from './hotTableContext'
@@ -211,6 +211,15 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
   }
 
   /**
+   * Detect if `hot-renderer` or `hot-editor` is defined, and if so, throw an incompatibility warning.
+   */
+  private displayObsoleteRenderersEditorsWarning(): void {
+    if (getChildElementByType(this.props.children, 'hot-renderer')) {
+      warn(OBSOLETE_HOTRENDERER_WARNING);
+    }
+  }
+
+  /**
    * Handsontable's `beforeViewRender` hook callback.
    */
   handsontableBeforeViewRender(): void {
@@ -256,6 +265,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
     (this.hotInstance as any).init();
 
     this.displayAutoSizeWarning(newGlobalSettings);
+    this.displayObsoleteRenderersEditorsWarning();
   }
 
   /**
@@ -268,6 +278,7 @@ class HotTableClass extends React.Component<HotTableProps, {}> {
 
     this.updateHot(newGlobalSettings);
     this.displayAutoSizeWarning(newGlobalSettings);
+    this.displayObsoleteRenderersEditorsWarning();
   }
 
   /**

--- a/wrappers/react/src/hotTableContext.tsx
+++ b/wrappers/react/src/hotTableContext.tsx
@@ -129,8 +129,8 @@ const HotTableContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const portalCacheArray = useRef<React.ReactPortal[]>([]);
 
   const getRendererWrapper = useCallback((Renderer: React.ComponentType<RendererProps>): typeof Handsontable.renderers.BaseRenderer => {
-    return function (instance, td, row, column, prop, value, cellProperties) {
-      const rowColKey = `${row}-${column}`
+    return function (instance, td, row, col, prop, value, cellProperties) {
+      const rowColKey = `${row}-${col}`
       if (renderedCellCache.current.has(rowColKey)) {
         td.innerHTML = renderedCellCache.current.get(rowColKey)!.innerHTML;
       }
@@ -140,7 +140,7 @@ const HotTableContextProvider: React.FC<PropsWithChildren> = ({ children }) => {
             <Renderer instance={instance}
                       td={td}
                       row={row}
-                      column={column}
+                      col={col}
                       prop={prop}
                       value={value}
                       cellProperties={cellProperties}/>

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -15,12 +15,12 @@ export type EditorScopeIdentifier = 'global' | number;
 /**
  * Type of the cache map for the Handsontable editor components.
  */
-export type HotEditorCache = Map<Function, Map<EditorScopeIdentifier, React.Component>>;
+export type HotEditorCache = Map<EditorScopeIdentifier, React.Component>;
 
 /**
- * Renderer props type
+ * Interface for the props of the component-based renderers.
  */
-export interface RendererProps {
+export interface HotRendererProps {
   instance: Handsontable.Core,
   td: HTMLTableCellElement,
   row: number,
@@ -31,12 +31,26 @@ export interface RendererProps {
 }
 
 /**
+ * Interface for the props of the component-based editors.
+ */
+export interface HotEditorProps {
+  id?: string,
+  className?: string,
+  style?: React.CSSProperties,
+
+  _editorColumnScope?: EditorScopeIdentifier,
+  _emitEditorInstance?: (editor: BaseEditorComponent, column: EditorScopeIdentifier) => void,
+}
+
+/**
  * Helper type to expose GridSettings/ColumnSettings props with native renderers/editors separately
  *  from component-based render prop.
  */
-type ReplaceRenderersEditors<T extends Pick<Handsontable.GridSettings, 'renderer'>> = Omit<T, 'renderer'> & {
+type ReplaceRenderersEditors<T extends Pick<Handsontable.GridSettings, 'renderer' | 'editor'>> = Omit<T, 'renderer' | 'editor'> & {
   hotRenderer?: T['renderer'],
-  renderer?: React.ComponentType<RendererProps>,
+  renderer?: React.ComponentType<HotRendererProps>,
+  hotEditor?: T['editor'],
+  editor?: React.ComponentType<HotEditorProps>,
 }
 
 /**
@@ -48,16 +62,6 @@ export interface HotTableProps extends ReplaceRenderersEditors<Handsontable.Grid
   className?: string,
   style?: React.CSSProperties,
   children?: React.ReactNode
-}
-
-/**
- * Interface for the props of the component-based editors.
- */
-export interface HotEditorProps {
-  "hot-editor": any,
-  id?: string,
-  className?: string,
-  style?: React.CSSProperties,
 }
 
 /**

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -18,10 +18,32 @@ export type EditorScopeIdentifier = 'global' | number;
 export type HotEditorCache = Map<Function, Map<EditorScopeIdentifier, React.Component>>;
 
 /**
+ * Renderer props type
+ */
+export interface RendererProps {
+  instance: Handsontable.Core,
+  td: HTMLTableCellElement,
+  row: number,
+  column: number,
+  prop: string | number,
+  value: any,
+  cellProperties: Handsontable.CellProperties
+}
+
+/**
+ * Helper type to expose GridSettings/ColumnSettings props with native rerenders/editors separately
+ *  from component-based render prop.
+ */
+type ReplaceRenderersEditors<T extends Handsontable.GridSettings> = Omit<T, 'renderer'> & {
+  hotRenderer?: T['renderer'],
+  renderer?: React.ComponentType<RendererProps>,
+}
+
+/**
  * Interface for the `prop` of the HotTable component - extending the default Handsontable settings with additional,
  * component-related properties.
  */
-export interface HotTableProps extends Handsontable.GridSettings {
+export interface HotTableProps extends ReplaceRenderersEditors<Handsontable.GridSettings> {
   id?: string,
   className?: string,
   style?: React.CSSProperties,

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -24,7 +24,7 @@ export interface RendererProps {
   instance: Handsontable.Core,
   td: HTMLTableCellElement,
   row: number,
-  column: number,
+  col: number,
   prop: string | number,
   value: any,
   cellProperties: Handsontable.CellProperties

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -31,10 +31,10 @@ export interface RendererProps {
 }
 
 /**
- * Helper type to expose GridSettings/ColumnSettings props with native rerenders/editors separately
+ * Helper type to expose GridSettings/ColumnSettings props with native renderers/editors separately
  *  from component-based render prop.
  */
-type ReplaceRenderersEditors<T extends Handsontable.GridSettings> = Omit<T, 'renderer'> & {
+type ReplaceRenderersEditors<T extends Pick<Handsontable.GridSettings, 'renderer'>> = Omit<T, 'renderer'> & {
   hotRenderer?: T['renderer'],
   renderer?: React.ComponentType<RendererProps>,
 }
@@ -63,6 +63,6 @@ export interface HotEditorProps {
 /**
  * Properties related to the HotColumn architecture.
  */
-export interface HotColumnProps extends Handsontable.ColumnSettings {
+export interface HotColumnProps extends ReplaceRenderersEditors<Handsontable.ColumnSettings> {
   children?: React.ReactNode;
 }

--- a/wrappers/react/src/types.tsx
+++ b/wrappers/react/src/types.tsx
@@ -1,11 +1,11 @@
 import Handsontable from 'handsontable/base';
 import React from 'react';
-import { ConnectedComponent } from 'react-redux';
+import BaseEditorComponent from './baseEditorComponent'
 
 /**
  * Type of the editor component's ReactElement.
  */
-export type HotEditorElement = React.ReactElement<{}, ConnectedComponent<React.FunctionComponent, any> | any>;
+export type HotEditorElement = React.ReactElement<HotEditorProps, any>;
 
 /**
  * Type of the identifier under which the cached editor components are stored.

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { act } from '@testing-library/react';
 import { HotTable } from '../src/hotTable';
 import { BaseEditorComponent } from '../src/baseEditorComponent';
+import { RendererProps } from '../src/types'
 
 const SPEC = {
   container: null,
@@ -205,15 +206,11 @@ class IndividualPropsWrapper extends React.Component<{ref?: string, id?: string}
 
 export { IndividualPropsWrapper };
 
-export class RendererComponent extends React.Component<any, any> {
-  render(): React.ReactElement<string> {
-    return (
-      <>
-        value: {this.props.value}
-      </>
-    );
-  }
-}
+export const RendererComponent: React.FC<RendererProps> = ({ value }) => (
+    <>
+      value: {value}
+    </>
+)
 
 export class EditorComponent extends BaseEditorComponent<{}, {value?: any}> {
   mainElementRef: any;

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { createRoot } from 'react-dom/client';
+import Handsontable from 'handsontable';
 import { act } from '@testing-library/react';
 import { HotTable } from '../src/hotTable';
 import { BaseEditorComponent } from '../src/baseEditorComponent';
@@ -211,6 +212,11 @@ export const RendererComponent: React.FC<RendererProps> = ({ value }) => (
       value: {value}
     </>
 )
+
+export const customNativeRenderer: Handsontable.renderers.BaseRenderer = function ( instance, td, row, col, prop, value, cellProperties) {
+  Handsontable.renderers.TextRenderer.apply(this, [instance, td, row, col, prop, `value: ${value}`, cellProperties]);
+  return td;
+}
 
 export class EditorComponent extends BaseEditorComponent<{}, {value?: any}> {
   mainElementRef: any;

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -213,7 +213,7 @@ export const RendererComponent: React.FC<RendererProps> = ({ value }) => (
     </>
 )
 
-export const customNativeRenderer: Handsontable.renderers.BaseRenderer = function ( instance, td, row, col, prop, value, cellProperties) {
+export const customNativeRenderer: Handsontable.renderers.BaseRenderer = function (instance, td, row, col, prop, value, cellProperties) {
   Handsontable.renderers.TextRenderer.apply(this, [instance, td, row, col, prop, `value: ${value}`, cellProperties]);
   return td;
 }

--- a/wrappers/react/test/_helpers.tsx
+++ b/wrappers/react/test/_helpers.tsx
@@ -4,7 +4,7 @@ import Handsontable from 'handsontable';
 import { act } from '@testing-library/react';
 import { HotTable } from '../src/hotTable';
 import { BaseEditorComponent } from '../src/baseEditorComponent';
-import { RendererProps } from '../src/types'
+import { HotRendererProps } from '../src/types'
 
 const SPEC = {
   container: null,
@@ -207,7 +207,7 @@ class IndividualPropsWrapper extends React.Component<{ref?: string, id?: string}
 
 export { IndividualPropsWrapper };
 
-export const RendererComponent: React.FC<RendererProps> = ({ value }) => (
+export const RendererComponent: React.FC<HotRendererProps> = ({ value }) => (
     <>
       value: {value}
     </>

--- a/wrappers/react/test/autoSizeWarning.spec.tsx
+++ b/wrappers/react/test/autoSizeWarning.spec.tsx
@@ -35,9 +35,8 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                 height={300}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <RendererComponent hot-renderer></RendererComponent>
-      </HotTable>
+                }}
+                renderer={RendererComponent}/>
     ));
 
     expect(console.warn).toHaveBeenCalledWith(AUTOSIZE_WARNING);
@@ -61,9 +60,8 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                 autoColumnSize={true}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <RendererComponent hot-renderer></RendererComponent>
-      </HotTable>
+                }}
+                renderer={RendererComponent}/>
     ));
 
     expect(console.warn).toHaveBeenCalledWith(AUTOSIZE_WARNING);
@@ -87,9 +85,7 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>
         <HotColumn/>
-        <HotColumn>
-          <RendererComponent hot-renderer></RendererComponent>
-        </HotColumn>
+        <HotColumn renderer={RendererComponent}/>
         <HotColumn/>
       </HotTable>
     ));
@@ -117,9 +113,7 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>
         <HotColumn/>
-        <HotColumn>
-          <RendererComponent hot-renderer></RendererComponent>
-        </HotColumn>
+        <HotColumn renderer={RendererComponent}/>
         <HotColumn/>
       </HotTable>
     ));
@@ -151,9 +145,7 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>
         <HotColumn/>
-        <HotColumn>
-          <RendererComponent hot-renderer/>
-        </HotColumn>
+        <HotColumn renderer={RendererComponent}/>
         <HotColumn/>
       </HotTable>
     ));
@@ -172,7 +164,7 @@ describe('`autoRowSize`/`autoColumns` warning', () => {
                 height={300}
                 autoRowSize={true}
                 autoColumnSize={false}
-                renderer={function() {}}
+                hotRenderer={function() {}}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
                 }}>

--- a/wrappers/react/test/autoSizeWarning.spec.tsx
+++ b/wrappers/react/test/autoSizeWarning.spec.tsx
@@ -17,6 +17,7 @@ import {
 
 registerAllModules();
 
+// TODO(3-hotrenderer-hoteditor) remove autosize issue
 describe('`autoRowSize`/`autoColumns` warning', () => {
   it('should recognize whether `autoRowSize` or `autoColumnSize` is enabled and throw a warning, if a global component-based renderer' +
     'is defined (using the default Handsontable settings - autoColumnSize is enabled by default)', async () => {

--- a/wrappers/react/test/componentInternals.spec.tsx
+++ b/wrappers/react/test/componentInternals.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from './_helpers';
 import { HOT_DESTROYED_WARNING } from "../src/helpers";
 import { BaseEditorComponent } from '../src/baseEditorComponent';
+import {RendererProps} from '../src'
 
 describe('Subcomponent state', () => {
   it('should be possible to set the state of the renderer components passed to HotTable and HotColumn', async () => {
@@ -46,20 +47,18 @@ describe('Subcomponent state', () => {
                 autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <RendererComponent2 ref={function (instance) {
-          if (instance && instance.props.row === 0 && instance.props.col === 0) {
-            zeroRendererInstance = instance;
-          }
-        }} hot-renderer></RendererComponent2>
+                }}
+                renderer={(props) => <RendererComponent2 {...props} ref={function (instance) {
+                  if (instance && props.row === 0 && props.col === 0) {
+                    zeroRendererInstance = instance;
+                  }
+                }} />}>
         <HotColumn/>
-        <HotColumn>
-          <RendererComponent2 ref={function (instance) {
-            if (instance && instance.props.row === 0 && instance.props.col === 1) {
-              oneRendererInstance = instance;
-            }
-          }} hot-renderer></RendererComponent2>
-        </HotColumn>
+        <HotColumn renderer={(props) => <RendererComponent2 {...props} ref={function (instance) {
+          if (instance && props.row === 0 && props.col === 1) {
+            oneRendererInstance = instance;
+          }
+        }} />}/>
       </HotTable>
     )).hotInstance;
 
@@ -145,7 +144,7 @@ describe('Subcomponent state', () => {
 
 describe('Component lifecyle', () => {
   it('renderer components should trigger their lifecycle methods', async () => {
-    class RendererComponent2 extends React.Component<any, any, any> {
+    class RendererComponent2 extends React.Component<RendererProps, any, any> {
       constructor(props) {
         super(props);
 
@@ -190,20 +189,18 @@ describe('Component lifecyle', () => {
                 autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <RendererComponent2 ref={function (instance) {
-          if (!secondGo && instance) {
-            rendererRefs.set(`${instance.props.row}-${instance.props.col}`, instance);
-          }
-        }} hot-renderer></RendererComponent2>
+                }}
+                renderer={(props) => <RendererComponent2 {...props} ref={function (instance) {
+                  if (!secondGo && instance) {
+                    rendererRefs.set(`${props.row}-${props.col}`, instance);
+                  }
+                }} />}>
         <HotColumn/>
-        <HotColumn>
-          <RendererComponent2 ref={function (instance) {
-            if (!secondGo && instance) {
-              rendererRefs.set(`${instance.props.row}-${instance.props.col}`, instance);
-            }
-          }} hot-renderer></RendererComponent2>
-        </HotColumn>
+        <HotColumn renderer={(props) => <RendererComponent2 {...props} ref={function (instance) {
+          if (!secondGo && instance) {
+            rendererRefs.set(`${props.row}-${props.col}`, instance);
+          }
+        }} />}/>
       </HotTable>
     ), false).hotInstance;
 

--- a/wrappers/react/test/componentInternals.spec.tsx
+++ b/wrappers/react/test/componentInternals.spec.tsx
@@ -10,7 +10,7 @@ import {
 } from './_helpers';
 import { HOT_DESTROYED_WARNING } from "../src/helpers";
 import { BaseEditorComponent } from '../src/baseEditorComponent';
-import { RendererProps } from '../src'
+import { HotRendererProps } from '../src'
 
 describe('Subcomponent state', () => {
   it('should be possible to set the state of the renderer components passed to HotTable and HotColumn', async () => {
@@ -144,7 +144,7 @@ describe('Subcomponent state', () => {
 
 describe('Component lifecyle', () => {
   it('renderer components should trigger their lifecycle methods', async () => {
-    class RendererComponent2 extends React.Component<RendererProps, any, any> {
+    class RendererComponent2 extends React.Component<HotRendererProps, any, any> {
       constructor(props) {
         super(props);
 

--- a/wrappers/react/test/componentInternals.spec.tsx
+++ b/wrappers/react/test/componentInternals.spec.tsx
@@ -10,7 +10,7 @@ import {
 } from './_helpers';
 import { HOT_DESTROYED_WARNING } from "../src/helpers";
 import { BaseEditorComponent } from '../src/baseEditorComponent';
-import {RendererProps} from '../src'
+import { RendererProps } from '../src'
 
 describe('Subcomponent state', () => {
   it('should be possible to set the state of the renderer components passed to HotTable and HotColumn', async () => {

--- a/wrappers/react/test/hotColumn.spec.tsx
+++ b/wrappers/react/test/hotColumn.spec.tsx
@@ -11,8 +11,10 @@ import {
   EditorComponent,
   simulateKeyboardEvent,
   simulateMouseEvent,
-  mountComponentWithRef
+  mountComponentWithRef,
+  customNativeRenderer
 } from './_helpers';
+import { OBSOLETE_HOTRENDERER_WARNING } from '../src/helpers'
 
 // register Handsontable's modules
 registerAllModules();
@@ -56,7 +58,117 @@ describe('Passing column settings using HotColumn', () => {
 });
 
 describe('Renderer configuration using React components', () => {
-  it('should use the renderer component as Handsontable renderer, when it\'s nested under HotColumn and assigned the \'hot-renderer\' attribute', async () => {
+  it('should use the renderer component as Handsontable renderer, when it\'s passed as component to HotColumn renderer prop', async () => {
+    const hotInstance = mountComponentWithRef((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(100, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn renderer={RendererComponent}/>
+      </HotTable>
+    )).hotInstance;
+
+    expect(hotInstance.getCell(0, 0).innerHTML).toEqual('A1');
+    expect(hotInstance.getCell(0, 1).innerHTML).toEqual('<div>value: B1</div>');
+
+    await act(async() => {
+      hotInstance.scrollViewportTo({
+        row: 99,
+        col: 0,
+      });
+      hotInstance.render();
+    });
+
+    await sleep(300);
+
+    expect(hotInstance.getCell(99, 0).innerHTML).toEqual('A100');
+    expect(hotInstance.getCell(99, 1).innerHTML).toEqual('<div>value: B100</div>');
+  });
+
+  it('should use the renderer component as Handsontable renderer, when it\'s passed inline to HotColumn renderer prop', async () => {
+    const hotInstance = mountComponentWithRef((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(100, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn renderer={(props) => <RendererComponent {...props} />}/>
+      </HotTable>
+    )).hotInstance;
+
+    expect(hotInstance.getCell(0, 0).innerHTML).toEqual('A1');
+    expect(hotInstance.getCell(0, 1).innerHTML).toEqual('<div>value: B1</div>');
+
+    await act(async() => {
+      hotInstance.scrollViewportTo({
+        row: 99,
+        col: 0,
+      });
+      hotInstance.render();
+    });
+
+    await sleep(300);
+
+    expect(hotInstance.getCell(99, 0).innerHTML).toEqual('A100');
+    expect(hotInstance.getCell(99, 1).innerHTML).toEqual('<div>value: B100</div>');
+  });
+
+  it('should use the renderer function as native Handsontable renderer, when it\'s passed to HotColumn hotRenderer prop', async () => {
+    const hotInstance = mountComponentWithRef((
+      <HotTable licenseKey="non-commercial-and-evaluation"
+                id="test-hot"
+                data={createSpreadsheetData(100, 2)}
+                width={300}
+                height={300}
+                rowHeights={23}
+                colWidths={50}
+                autoRowSize={false}
+                autoColumnSize={false}
+                init={function () {
+                  mockElementDimensions(this.rootElement, 300, 300);
+                }}>
+        <HotColumn/>
+        <HotColumn hotRenderer={customNativeRenderer}/>
+      </HotTable>
+    )).hotInstance;
+
+    expect(hotInstance.getCell(0, 0).innerHTML).toEqual('A1');
+    expect(hotInstance.getCell(0, 1).innerHTML).toEqual('value: B1');
+
+    await act(async() => {
+      hotInstance.scrollViewportTo({
+        row: 99,
+        col: 0,
+      });
+      hotInstance.render();
+    });
+
+    await sleep(300);
+
+    expect(hotInstance.getCell(99, 0).innerHTML).toEqual('A100');
+    expect(hotInstance.getCell(99, 1).innerHTML).toEqual('value: B100');
+  });
+
+  it('should issue a warning when the renderer component is nested under HotColumn and assigned the \'hot-renderer\' attribute', async () => {
+    console.warn = jasmine.createSpy('warn');
+
     const hotInstance = mountComponentWithRef((
       <HotTable licenseKey="non-commercial-and-evaluation"
                 id="test-hot"
@@ -77,21 +189,9 @@ describe('Renderer configuration using React components', () => {
       </HotTable>
     )).hotInstance;
 
-    expect(hotInstance.getCell(0, 0).innerHTML).toEqual('A1');
-    expect(hotInstance.getCell(0, 1).innerHTML).toEqual('<div>value: B1</div>');
+    expect(hotInstance.getCell(0, 1).innerHTML).not.toEqual('<div>value: B1</div>');
 
-    await act(async() => {
-      hotInstance.scrollViewportTo({
-        row: 99,
-        col: 0,
-      });
-      hotInstance.render();
-    });
-
-    await sleep(300);
-
-    expect(hotInstance.getCell(99, 0).innerHTML).toEqual('A100');
-    expect(hotInstance.getCell(99, 1).innerHTML).toEqual('<div>value: B100</div>');
+    expect(console.warn).toHaveBeenCalledWith(OBSOLETE_HOTRENDERER_WARNING);
   });
 });
 
@@ -300,9 +400,7 @@ describe('Dynamic HotColumn configuration changes', () => {
           <HotColumn title="test title 2" key={'2'}>
             <RendererComponent2 hot-renderer></RendererComponent2>
           </HotColumn>,
-          <HotColumn title="test title" className="first-column-class-name" key={'3'}>
-            <RendererComponent hot-renderer/>
-          </HotColumn>
+          <HotColumn title="test title" className="first-column-class-name" key={'3'} renderer={RendererComponent}/>
         ]
       });
     });

--- a/wrappers/react/test/hotColumn.spec.tsx
+++ b/wrappers/react/test/hotColumn.spec.tsx
@@ -322,13 +322,10 @@ describe('Dynamic HotColumn configuration changes', () => {
 
         this.state = {
           setup: [
-            <RendererComponent hot-renderer key={'1'}/>,
             <HotColumn title="test title" className="first-column-class-name" key={'2'}>
               <EditorComponent className="editor-className-1" id="editor-id-1" style={{background: 'red'}} hot-editor/>
             </HotColumn>,
-            <HotColumn title="test title 2" key={'3'}>
-              <RendererComponent2 hot-renderer></RendererComponent2>
-            </HotColumn>
+            <HotColumn title="test title 2" key={'3'} renderer={RendererComponent2} />
           ]
         }
       }
@@ -347,6 +344,7 @@ describe('Dynamic HotColumn configuration changes', () => {
                     init={function () {
                       mockElementDimensions(this.rootElement, 300, 300);
                     }}
+                    renderer={(props) => <RendererComponent {...props} key={'1'}/>}
                     ref={hotTableInstanceRef}>
             {this.state.setup}
           </HotTable>
@@ -397,9 +395,7 @@ describe('Dynamic HotColumn configuration changes', () => {
       wrapperComponentInstance.setState({
         setup: [
           <EditorComponent className="editor-className-2" id="editor-id-2" style={{background: 'blue'}} hot-editor key={'1'}/>,
-          <HotColumn title="test title 2" key={'2'}>
-            <RendererComponent2 hot-renderer></RendererComponent2>
-          </HotColumn>,
+          <HotColumn title="test title 2" key={'2'} renderer={RendererComponent2}/>,
           <HotColumn title="test title" className="first-column-class-name" key={'3'} renderer={RendererComponent}/>
         ]
       });

--- a/wrappers/react/test/hotTable.spec.tsx
+++ b/wrappers/react/test/hotTable.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { act } from '@testing-library/react';
-import Handsontable from 'handsontable';
 import { registerAllModules } from 'handsontable/registry';
 import {
   HotTable
@@ -14,11 +13,12 @@ import {
   sleep,
   simulateKeyboardEvent,
   simulateMouseEvent,
-  mountComponentWithRef
+  mountComponentWithRef,
+  customNativeRenderer
 } from './_helpers';
 import { OBSOLETE_HOTRENDERER_WARNING } from '../src/helpers'
-import { BaseRenderer } from 'handsontable/renderers';
 
+// register Handsontable's modules
 registerAllModules();
 
 describe('Handsontable initialization', () => {
@@ -207,12 +207,7 @@ describe('Renderer configuration using React components', () => {
     expect(hotInstance.getCell(99, 99).innerHTML).toEqual('<div>value: CV100</div>');
   });
 
-  it('should use the renderer function as native Handsontable renderer, when it\'s passed to HotTable hotRerender prop', async () => {
-    const customNativeRenderer: BaseRenderer = function ( instance, td, row, col, prop, value, cellProperties) {
-      Handsontable.renderers.TextRenderer.apply(this, [instance, td, row, col, prop, `value: ${value}`, cellProperties]);
-      return td;
-    }
-
+  it('should use the renderer function as native Handsontable renderer, when it\'s passed to HotTable hotRenderer prop', async () => {
     const hotInstance = mountComponentWithRef((
       <HotTable licenseKey="non-commercial-and-evaluation"
                 id="test-hot"

--- a/wrappers/react/test/reactContext.spec.tsx
+++ b/wrappers/react/test/reactContext.spec.tsx
@@ -7,7 +7,7 @@ import {
   mountComponentWithRef
 } from './_helpers';
 import { BaseEditorComponent } from '../src/baseEditorComponent';
-import { RendererProps } from '../src'
+import { HotRendererProps } from '../src'
 
 describe('React Context', () => {
   it('should be possible to declare a context and use it inside both renderers and editors', async () => {
@@ -32,7 +32,7 @@ describe('React Context', () => {
       }
     }
 
-    class RendererComponent3 extends React.Component<RendererProps> {
+    class RendererComponent3 extends React.Component<HotRendererProps> {
       render() {
         return (
           <>

--- a/wrappers/react/test/reactContext.spec.tsx
+++ b/wrappers/react/test/reactContext.spec.tsx
@@ -11,6 +11,7 @@ import {
   mountComponentWithRef
 } from './_helpers';
 import { BaseEditorComponent } from '../src/baseEditorComponent';
+import {RendererProps} from '../src'
 
 describe('React Context', () => {
   it('should be possible to declare a context and use it inside both renderers and editors', async () => {
@@ -35,7 +36,7 @@ describe('React Context', () => {
       }
     }
 
-    class RendererComponent3 extends React.Component {
+    class RendererComponent3 extends React.Component<RendererProps> {
       render() {
         return (
           <>
@@ -74,12 +75,10 @@ describe('React Context', () => {
                   ref={function (instance) {
                     hotTableInstance = instance;
                   }}>
-          <HotColumn>
-            <RendererComponent2 hot-renderer/>
+          <HotColumn renderer={RendererComponent2}>
             <EditorComponent2 hot-editor className="ec2"/>
           </HotColumn>
-          <HotColumn>
-            <RendererComponent3 hot-renderer/>
+          <HotColumn renderer={RendererComponent3}>
             <EditorComponent3 hot-editor className="ec3"/>
           </HotColumn>
         </HotTable>

--- a/wrappers/react/test/reactContext.spec.tsx
+++ b/wrappers/react/test/reactContext.spec.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
-import {
-  HotTable
-} from '../src/hotTable';
-import {
-  HotColumn
-} from '../src/hotColumn';
+import { HotTable } from '../src/hotTable';
+import { HotColumn } from '../src/hotColumn';
 import {
   createSpreadsheetData,
   mockElementDimensions,
   mountComponentWithRef
 } from './_helpers';
 import { BaseEditorComponent } from '../src/baseEditorComponent';
-import {RendererProps} from '../src'
+import { RendererProps } from '../src'
 
 describe('React Context', () => {
   it('should be possible to declare a context and use it inside both renderers and editors', async () => {

--- a/wrappers/react/test/reactHooks.spec.tsx
+++ b/wrappers/react/test/reactHooks.spec.tsx
@@ -37,9 +37,8 @@ describe('Using hooks within HotTable renderers', () => {
                 autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <HookEnabledRenderer hot-renderer></HookEnabledRenderer>
-      </HotTable>
+                }}
+                renderer={HookEnabledRenderer}/>
     )).hotInstance;
 
     expect(hotInstance.getCell(0, 0).querySelectorAll('.hook-enabled-renderer-container').length).toEqual(1);

--- a/wrappers/react/test/reactLazy.spec.tsx
+++ b/wrappers/react/test/reactLazy.spec.tsx
@@ -49,9 +49,8 @@ describe('React.lazy', () => {
                 autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <SuspendedRenderer hot-renderer/>
-      </HotTable>
+                }}
+                renderer={SuspendedRenderer}/>
     )).hotInstance;
 
     expect(hotInstance.getCell(0, 0).innerHTML).toEqual('<div>loading-message</div>');

--- a/wrappers/react/test/reactMemo.spec.tsx
+++ b/wrappers/react/test/reactMemo.spec.tsx
@@ -38,9 +38,8 @@ describe('React.memo', () => {
                 autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <MemoizedRendererComponent2 hot-renderer/>
-      </HotTable>
+                }}
+                renderer={MemoizedRendererComponent2}/>
     )).hotInstance;
 
     await act(async () => {

--- a/wrappers/react/test/reactPureComponent.spec.tsx
+++ b/wrappers/react/test/reactPureComponent.spec.tsx
@@ -36,9 +36,8 @@ describe('React PureComponents', () => {
                 autoColumnSize={false}
                 init={function () {
                   mockElementDimensions(this.rootElement, 300, 300);
-                }}>
-        <RendererComponent2 hot-renderer/>
-      </HotTable>
+                }}
+                renderer={RendererComponent2}/>
     )).hotInstance;
 
     expect(hotInstance.getCell(0, 0).innerHTML).toEqual('<div>value: A1</div>');

--- a/wrappers/react/test/redux.spec.tsx
+++ b/wrappers/react/test/redux.spec.tsx
@@ -68,16 +68,15 @@ describe('Using Redux store within HotTable renderers and editors', () => {
                   autoColumnSize={false}
                   init={function () {
                     mockElementDimensions(this.rootElement, 300, 300);
-                  }}>
-          <ReduxEnabledRenderer ref={function (instance) {
-            if (instance === null) {
-              return instance;
-            }
+                  }}
+                  renderer={(props) => <ReduxEnabledRenderer {...props} ref={function (instance) {
+                    if (instance === null) {
+                      return instance;
+                    }
 
-            rendererInstances.set(`${instance.props.row}-${instance.props.col}`, instance);
-          }
-          } hot-renderer/>
-        </HotTable>
+                    rendererInstances.set(`${instance.props.row}-${instance.props.col}`, instance);
+                  }
+                  } />} />
       </Provider>
     ));
 


### PR DESCRIPTION

### Context
<!--- Why is this change required? What problem does it solve? -->

### How has this been tested?
<!--- Please describe in detail how you tested your changes (doesn't apply to translations). -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature or improvement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Additional language file or change to the existing one (translations)

### Related issue(s):
1.
2.
3.

### Affected project(s):
- [ ] `handsontable`
- [ ] `@handsontable/angular`
- [x] `@handsontable/react`
- [ ] `@handsontable/vue`
- [ ] `@handsontable/vue3`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the guidelines about [Contributing to Handsontable](https://github.com/handsontable/handsontable/blob/master/CONTRIBUTING.md) and I confirm that my code follows the code style of this project.
- [x] I have signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1)
- [x] My change requires a change to the documentation.
